### PR TITLE
CI 빌드 에러 해결 및 테스트 프로파일 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build-Test
         run: |
           chmod +x ./gradlew
-          ./gradlew clean build
+          ./gradlew clean build -Dspring.profiles.active=test
 
       # 실패시
       - name: Build Fail Comment

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // ... 기존에 적어주신 testImplementation들 아래에 추가 ...
+    // test시 활용할 가짜 DB
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/team6/backend/SixCanDoEatApplicationTests.java
+++ b/src/test/java/com/team6/backend/SixCanDoEatApplicationTests.java
@@ -1,10 +1,31 @@
 package com.team6.backend;
 
+import com.team6.backend.global.infrastructure.config.security.jwt.JwtUtil;
+import com.team6.backend.global.infrastructure.redis.RedisService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
+@ActiveProfiles("test") // application-test.yml 사용
 class SixCanDoEatApplicationTests {
+
+    // TODO
+    // @MockitoBean -> 위 부분들은 ci.yml파일을 위해 junit-test를 위해 작성
+    // 후에 juit test시 단위 테스트와 통합 테스트 분리 필
+    // 이때는 하단과 같이 redis를 mock이 아닌 테스트용 Redis 직접 필요.
+    // Redis 관련 빈들을 Mock(가짜)으로 대체하여 실제 Redis 없이도 서버가 뜨게 만듭니다.
+    @MockitoBean
+    private RedisService redisService;
+
+    @MockitoBean
+    private StringRedisTemplate stringRedisTemplate;
+
+    // JwtUtil도 Mock으로 대체하여 환경 변수 주입 과정을 생략합니다.
+    @MockitoBean
+    private JwtUtil jwtUtil;
 
     @Test
     void contextLoads() {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+  
+  # TODO 통합 테스트에서 테스트용 redis 사용시 삭제할 것
+  # Redis 설정 (spring 계층 아래에 한 번만 작성)
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+# JWT 및 직접 참조형 환경 변수 (최상단 레벨)
+jwt:
+  secret:
+    key: "test_secret_key_for_testing_purposes_only_1234567890"
+
+# @Value("${REDIS_PORT}") 등을 위한 설정
+REDIS_HOST: localhost
+REDIS_PORT: 6379
+JWT_SECRET_KEY: "test_secret_key_for_testing_purposes_only_1234567890"


### PR DESCRIPTION
## 📌 개요
- 외부 인프라 의존성으로 인해 CI 빌드가 실패하던 문제를 해결하고, 안정적인 테스트 환경을 구축했습니다.

## ✨ 주요 작업 내용
1. **테스트 환경 격리**
   - `src/test/resources/application-test.yml`을 생성하여 CI 환경에서도 독립적으로 동작하도록 설정했습니다.
   - Database: H2 인메모리 DB를 활용하여 실제 DB 연결 없이도 JPA 엔티티 검증이 가능하도록 했습니다.

2. **외부 인프라 모킹 (Mocking)**
   - Redis 서버가 없는 환경에서도 어플리케이션 컨텍스트가 로드될 수 있도록 `RedisService`, `StringRedisTemplate`을 `@MockitoBean`으로 대체했습니다.
   - JWT 검증에 필요한 시크릿 키 주입 에러를 방지하기 위해 `JwtUtil`을 Mocking 처리했습니다.

3. **CI 파이프라인 수정**
   - `./gradlew build` 시 `-Dspring.profiles.active=test` 옵션을 추가하여 테스트 프로파일이 적용되도록 수정했습니다.

## 📸 테스트 결과
- 로컬 환경 및 CI 환경에서 `contextLoads()` 테스트 통과 확인 
<img width="1776" height="477" alt="스크린샷 2026-04-20 183054" src="https://github.com/user-attachments/assets/f41ebbaa-96d4-4f8d-bc5d-f5cd06e65b87" />


## 💬 리뷰어에게
- 현재는 전체 컨텍스트 로딩을 확인하기 위해 임시로 Mocking을 사용했습니다. 추후 기능 개발에 따라 단위 테스트로 분리하거나, 필요한 경우 Embedded Redis 도입을 검토할 예정입니다.

Close #7 