### PR TITLE
refactor: Store 공통 엔티티 규칙 적용 및 가게 목록 조회 기능 수정

### DIFF
--- a/src/main/java/com/team6/backend/review/application/service/ReviewService.java
+++ b/src/main/java/com/team6/backend/review/application/service/ReviewService.java
@@ -91,7 +91,7 @@ public class ReviewService {
                 isAsc ? Sort.by(sortBy).ascending() : Sort.by(sortBy).descending()
         );
 
-        Page<ReviewEntity> reviewList = reviewRepository.findByStore_IdAndDeletedAtIsNull(storeId, pageable);
+        Page<ReviewEntity> reviewList = reviewRepository.findByStore_StoreIdAndDeletedAtIsNull(storeId, pageable);
 
         return reviewList.map(ReviewResponseDto::new);
     }

--- a/src/main/java/com/team6/backend/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/team6/backend/review/domain/repository/ReviewRepository.java
@@ -13,5 +13,5 @@ public interface ReviewRepository extends JpaRepository<ReviewEntity, UUID> {
     boolean existsByOrder_Id(UUID orderId);
 
     @EntityGraph(attributePaths = {"user", "store", "order"})
-    Page<ReviewEntity> findByStore_IdAndDeletedAtIsNull(UUID storeId, Pageable pageable);
+    Page<ReviewEntity> findByStore_StoreIdAndDeletedAtIsNull(UUID storeId, Pageable pageable);
 }

--- a/src/main/java/com/team6/backend/review/presentation/dto/response/ReviewResponseDto.java
+++ b/src/main/java/com/team6/backend/review/presentation/dto/response/ReviewResponseDto.java
@@ -24,7 +24,7 @@ public class ReviewResponseDto {
     public ReviewResponseDto(ReviewEntity review) {
         this.reviewId = review.getId();
         this.userId = review.getUser().getId();
-        this.storeId = review.getStore().getId();
+        this.storeId = review.getStore().getStoreId();
         this.orderId = review.getOrder().getId();
         this.content = review.getContent();
         this.rating = review.getRating();

--- a/src/main/java/com/team6/backend/store/application/service/StoreService.java
+++ b/src/main/java/com/team6/backend/store/application/service/StoreService.java
@@ -1,6 +1,5 @@
 package com.team6.backend.store.application.service;
 
-import com.team6.backend.auth.domain.repository.UserRepository;
 import com.team6.backend.global.infrastructure.config.security.util.SecurityUtils;
 import com.team6.backend.global.infrastructure.exception.ApplicationException;
 import com.team6.backend.global.infrastructure.exception.CommonErrorCode;
@@ -10,7 +9,6 @@ import com.team6.backend.store.domain.repository.StoreRepository;
 import com.team6.backend.store.presentation.dto.request.StoreRequest;
 import com.team6.backend.store.presentation.dto.response.StoreResponse;
 import com.team6.backend.user.domain.entity.Role;
-import com.team6.backend.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,14 +24,11 @@ import java.util.UUID;
 public class StoreService {
 
     private final StoreRepository storeRepository;
-    private final UserRepository userRepository;
     private final SecurityUtils securityUtils;
 
     @Transactional
     public StoreResponse createStore(StoreRequest request) {
         UUID userId = securityUtils.getCurrentUserId();
-        userRepository.findById(userId)
-                .orElseThrow(() -> new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
         Store store = new Store(userId, request.getCategoryId(), request.getAreaId(), request.getName(), request.getAddress());
         Store saved =  storeRepository.save(store);
@@ -41,12 +36,12 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
-    public Page<StoreResponse> getStores(int page, int size, String sortBy, boolean isAsc) {
+    public Page<StoreResponse> getStores(String keyword, UUID categoryId, UUID areaId, int page, int size, String sortBy, boolean isAsc) {
         Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
         Sort sort = Sort.by(direction, sortBy);
         Pageable pageable = PageRequest.of(page, size, sort);
 
-        Page<Store> storeList = storeRepository.findAll(pageable);
+        Page<Store> storeList = storeRepository.searchStores(keyword, categoryId, areaId, pageable);
 
         return storeList.map(StoreResponse::new);
     }
@@ -69,7 +64,7 @@ public class StoreService {
     public void deleteStore(UUID storeId) {
         Store store = findStoreById(storeId);
         checkValidAccess(store);
-        storeRepository.delete(store);
+        store.markDeleted(securityUtils.getCurrentUserId().toString());
     }
 
     @Transactional
@@ -90,9 +85,10 @@ public class StoreService {
         Role role = securityUtils.getCurrentUserRole();
         if (role == Role.CUSTOMER)
             throw (new ApplicationException(CommonErrorCode.FORBIDDEN));
-        else if (role == Role.OWNER) {
-            if (store.getOwnerId() != securityUtils.getCurrentUserId())
-                throw (new ApplicationException(CommonErrorCode.FORBIDDEN));
+
+        UUID userId = securityUtils.getCurrentUserId();
+        if (role == Role.OWNER && !store.getOwnerId().equals(userId)) {
+            throw (new ApplicationException(CommonErrorCode.FORBIDDEN));
         }
     }
 }

--- a/src/main/java/com/team6/backend/store/domain/entity/Store.java
+++ b/src/main/java/com/team6/backend/store/domain/entity/Store.java
@@ -1,25 +1,25 @@
 package com.team6.backend.store.domain.entity;
 
-import com.team6.backend.user.domain.entity.User;
-import com.team6.backend.menu.domain.entity.Menu;
+import com.team6.backend.global.infrastructure.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
-import java.util.List;
 import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "p_store")
-public class Store {
+@SQLRestriction("deleted_at IS NULL")
+public class Store extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "store_id")
-    private UUID id;
+    private UUID StoreId;
 
     @Column(name = "owner_id", nullable = false)
     private UUID ownerId;

--- a/src/main/java/com/team6/backend/store/domain/entity/Store.java
+++ b/src/main/java/com/team6/backend/store/domain/entity/Store.java
@@ -19,7 +19,7 @@ public class Store extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "store_id")
-    private UUID StoreId;
+    private UUID storeId;
 
     @Column(name = "owner_id", nullable = false)
     private UUID ownerId;

--- a/src/main/java/com/team6/backend/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/team6/backend/store/domain/repository/StoreRepository.java
@@ -1,9 +1,23 @@
 package com.team6.backend.store.domain.repository;
 
 import com.team6.backend.store.domain.entity.Store;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.UUID;
 
 public interface StoreRepository extends JpaRepository<Store, UUID> {
+    // TODO: QueryDsl 적용해야 함
+    @Query("SELECT s FROM Store s WHERE " +
+            "(:keyword IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) AND " +
+            "(:categoryId IS NULL OR s.categoryId = :categoryId) AND " +
+            "(:areaId IS NULL OR s.areaId = :areaId)")
+    Page<Store> searchStores(
+            @Param("keyword") String keyword,
+            @Param("categoryId") UUID categoryId,
+            @Param("areaId") UUID areaId,
+            Pageable pageable);
 }

--- a/src/main/java/com/team6/backend/store/presentation/controller/StoreController.java
+++ b/src/main/java/com/team6/backend/store/presentation/controller/StoreController.java
@@ -34,12 +34,15 @@ public class StoreController {
     /* 가게 목록 조회 */
     @GetMapping
     public ResponseEntity<SuccessResponse<Page<StoreResponse>>> getStores(
-            @RequestParam("page") int page,
-            @RequestParam("size") int size,
-            @RequestParam("sortBy") String sortBy,
-            @RequestParam("isAsc") boolean isAsc
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) UUID categoryId,
+            @RequestParam(required = false) UUID areaId,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "10") int size,
+            @RequestParam(required = false, defaultValue = "createdAt") String sortBy,
+            @RequestParam(required = false, defaultValue = "false") boolean isAsc
     ) {
-        Page<StoreResponse> stores = storeService.getStores(page, size, sortBy, isAsc);
+        Page<StoreResponse> stores = storeService.getStores(keyword, categoryId, areaId, page, size, sortBy, isAsc);
         return ResponseEntity.ok(SuccessResponse.ok(stores));
     }
 

--- a/src/main/java/com/team6/backend/store/presentation/dto/response/StoreResponse.java
+++ b/src/main/java/com/team6/backend/store/presentation/dto/response/StoreResponse.java
@@ -16,7 +16,7 @@ public class StoreResponse {
     private final boolean isHidden;
 
     public StoreResponse(Store store) {
-        this.storeId = store.getId();
+        this.storeId = store.getStoreId();
         this.categoryId = store.getCategoryId();
         this.areaId = store.getAreaId();
         this.name = store.getName();

--- a/src/test/java/com/team6/backend/store/application/service/StoreServiceTest.java
+++ b/src/test/java/com/team6/backend/store/application/service/StoreServiceTest.java
@@ -1,0 +1,201 @@
+package com.team6.backend.store.application.service;
+
+import com.team6.backend.global.infrastructure.config.security.util.SecurityUtils;
+import com.team6.backend.global.infrastructure.exception.ApplicationException;
+import com.team6.backend.global.infrastructure.exception.CommonErrorCode;
+import com.team6.backend.global.infrastructure.exception.StoreErrorCode;
+import com.team6.backend.store.domain.entity.Store;
+import com.team6.backend.store.domain.repository.StoreRepository;
+import com.team6.backend.store.presentation.dto.request.StoreRequest;
+import com.team6.backend.store.presentation.dto.response.StoreResponse;
+import com.team6.backend.user.domain.entity.Role;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private SecurityUtils securityUtils;
+
+    @InjectMocks
+    private StoreService storeService;
+
+    // 테스트용 공통 데이터
+    private final UUID ownerId = UUID.randomUUID();
+    private final UUID storeId = UUID.randomUUID();
+    private final UUID categoryId = UUID.randomUUID();
+    private final UUID areaId = UUID.randomUUID();
+
+    private Store createMockStore(UUID ownerId) {
+        Store store = new Store(ownerId, categoryId, areaId, "테스트 가게", "서울시 강남구");
+        ReflectionTestUtils.setField(store, "StoreId", storeId);
+        return store;
+    }
+
+    private StoreRequest createStoreRequest() {
+        StoreRequest request = new StoreRequest();
+        ReflectionTestUtils.setField(request, "name", "수정된 가게");
+        ReflectionTestUtils.setField(request, "categoryId", categoryId);
+        ReflectionTestUtils.setField(request, "areaId", areaId);
+        ReflectionTestUtils.setField(request, "address", "수정된 주소");
+        return request;
+    }
+
+    // ==========================================
+    // 성공 케이스
+    // ==========================================
+
+    @Test
+    @DisplayName("가게 생성 성공")
+    void createStore_Success() {
+        // given
+        StoreRequest request = createStoreRequest();
+        Store store = createMockStore(ownerId);
+
+        given(securityUtils.getCurrentUserId()).willReturn(ownerId);
+        given(storeRepository.save(any(Store.class))).willReturn(store);
+
+        // when
+        StoreResponse response = storeService.createStore(request);
+
+        // then
+        assertThat(response.getName()).isEqualTo("테스트 가게");
+        verify(storeRepository).save(any(Store.class));
+    }
+
+    @Test
+    @DisplayName("가게 목록 조회 성공")
+    void getStores_Success() {
+        // given
+        Store store = createMockStore(ownerId);
+        Page<Store> storePage = new PageImpl<>(Collections.singletonList(store));
+        given(storeRepository.searchStores(any(), any(), any(), any(Pageable.class))).willReturn(storePage);
+
+        // when
+        Page<StoreResponse> result = storeService.getStores("테스트", categoryId, areaId, 0, 10, "createdAt", false);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getName()).isEqualTo("테스트 가게");
+    }
+
+    @Test
+    @DisplayName("가게 정보 수정 성공 - OWNER 본인 가게")
+    void updateStore_Success() {
+        // given
+        Store store = createMockStore(ownerId);
+        StoreRequest request = createStoreRequest();
+
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(securityUtils.getCurrentUserRole()).willReturn(Role.OWNER);
+        given(securityUtils.getCurrentUserId()).willReturn(ownerId);
+
+        // when
+        StoreResponse response = storeService.updateStore(storeId, request);
+
+        // then
+        assertThat(response.getName()).isEqualTo("수정된 가게");
+    }
+
+    @Test
+    @DisplayName("가게 삭제 성공 - OWNER 본인 가게")
+    void deleteStore_Success() {
+        // given
+        Store store = createMockStore(ownerId);
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(securityUtils.getCurrentUserRole()).willReturn(Role.OWNER);
+        given(securityUtils.getCurrentUserId()).willReturn(ownerId);
+
+        // when
+        storeService.deleteStore(storeId);
+
+        // then
+        assertThat(store.isDeleted()).isTrue();
+    }
+
+    // ==========================================
+    // 실패 케이스
+    // ==========================================
+
+    @Test
+    @DisplayName("가게 상세 조회 실패 - 존재하지 않는 가게")
+    void getStoreById_Fail_NotFound() {
+        // given
+        given(storeRepository.findById(storeId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> storeService.getStoreById(storeId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(StoreErrorCode.STORE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("가게 수정 실패 - CUSTOMER 권한 접근 불가")
+    void updateStore_Fail_Forbidden_Customer() {
+        // given
+        Store store = createMockStore(ownerId);
+        StoreRequest request = createStoreRequest();
+
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(securityUtils.getCurrentUserRole()).willReturn(Role.CUSTOMER);
+
+        // when & then
+        assertThatThrownBy(() -> storeService.updateStore(storeId, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(CommonErrorCode.FORBIDDEN.getMessage());
+    }
+
+    @Test
+    @DisplayName("가게 수정 실패 - 다른 OWNER의 가게 접근")
+    void updateStore_Fail_Forbidden_AnotherOwner() {
+        // given
+        Store store = createMockStore(ownerId);
+        StoreRequest request = createStoreRequest();
+        UUID anotherOwnerId = UUID.randomUUID();
+
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(securityUtils.getCurrentUserRole()).willReturn(Role.OWNER);
+        given(securityUtils.getCurrentUserId()).willReturn(anotherOwnerId);
+
+        // when & then
+        assertThatThrownBy(() -> storeService.updateStore(storeId, request))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(CommonErrorCode.FORBIDDEN.getMessage());
+    }
+
+    @Test
+    @DisplayName("가게 숨김 처리 실패 - 권한 없음")
+    void hideStore_Fail_Forbidden() {
+        // given
+        Store store = createMockStore(ownerId);
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(securityUtils.getCurrentUserRole()).willReturn(Role.CUSTOMER);
+
+        // when & then
+        assertThatThrownBy(() -> storeService.hideStore(storeId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(CommonErrorCode.FORBIDDEN.getMessage());
+    }
+}

--- a/src/test/java/com/team6/backend/store/application/service/StoreServiceTest.java
+++ b/src/test/java/com/team6/backend/store/application/service/StoreServiceTest.java
@@ -50,7 +50,7 @@ class StoreServiceTest {
 
     private Store createMockStore(UUID ownerId) {
         Store store = new Store(ownerId, categoryId, areaId, "테스트 가게", "서울시 강남구");
-        ReflectionTestUtils.setField(store, "StoreId", storeId);
+        ReflectionTestUtils.setField(store, "storeId", storeId);
         return store;
     }
 

--- a/src/test/java/com/team6/backend/store/presentation/controller/StoreControllerTest.java
+++ b/src/test/java/com/team6/backend/store/presentation/controller/StoreControllerTest.java
@@ -104,20 +104,20 @@ class StoreControllerTest {
                 .andExpect(status().isForbidden());
     }
 
-    @Test
-    @DisplayName("가게 목록 조회 - Customer1 성공 (200 OK)")
-    @WithMockUser(username = "customer1", roles = "CUSTOMER")
-    void getStores_ByCustomer1_ShouldSucceed() throws Exception {
-        given(storeService.getStores(anyInt(), anyInt(), anyString(), anyBoolean()))
-                .willReturn(new PageImpl<>(Collections.singletonList(mockResponse)));
-
-        mockMvc.perform(get("/api/v1/stores")
-                        .param("page", "0")
-                        .param("size", "10")
-                        .param("sortBy", "createdAt")
-                        .param("isAsc", "false"))
-                .andExpect(status().isOk());
-    }
+//    @Test
+//    @DisplayName("가게 목록 조회 - Customer1 성공 (200 OK)")
+//    @WithMockUser(username = "customer1", roles = "CUSTOMER")
+//    void getStores_ByCustomer1_ShouldSucceed() throws Exception {
+//        given(storeService.getStores(anyInt(), anyInt(), anyString(), anyBoolean()))
+//                .willReturn(new PageImpl<>(Collections.singletonList(mockResponse)));
+//
+//        mockMvc.perform(get("/api/v1/stores")
+//                        .param("page", "0")
+//                        .param("size", "10")
+//                        .param("sortBy", "createdAt")
+//                        .param("isAsc", "false"))
+//                .andExpect(status().isOk());
+//    }
 
     @Test
     @DisplayName("가게 정보 수정 - Manager1 성공 (200 OK)")

--- a/src/test/java/com/team6/backend/store/presentation/controller/StoreControllerTest.java
+++ b/src/test/java/com/team6/backend/store/presentation/controller/StoreControllerTest.java
@@ -104,20 +104,22 @@ class StoreControllerTest {
                 .andExpect(status().isForbidden());
     }
 
-//    @Test
-//    @DisplayName("가게 목록 조회 - Customer1 성공 (200 OK)")
-//    @WithMockUser(username = "customer1", roles = "CUSTOMER")
-//    void getStores_ByCustomer1_ShouldSucceed() throws Exception {
-//        given(storeService.getStores(anyInt(), anyInt(), anyString(), anyBoolean()))
-//                .willReturn(new PageImpl<>(Collections.singletonList(mockResponse)));
-//
-//        mockMvc.perform(get("/api/v1/stores")
-//                        .param("page", "0")
-//                        .param("size", "10")
-//                        .param("sortBy", "createdAt")
-//                        .param("isAsc", "false"))
-//                .andExpect(status().isOk());
-//    }
+    @Test
+    @DisplayName("가게 목록 조회 - Customer1 성공 (200 OK)")
+    @WithMockUser(username = "customer1", roles = "CUSTOMER")
+    void getStores_ByCustomer1_ShouldSucceed() throws Exception {
+        given(storeService.getStores(any(), any(), any(), anyInt(), anyInt(), anyString(), anyBoolean()))
+                .willReturn(new PageImpl<>(Collections.singletonList(mockResponse)));
+
+        mockMvc.perform(get("/api/v1/stores")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sortBy", "createdAt")
+                        .param("isAsc", "false"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("COMMON_200"))
+                .andExpect(jsonPath("$.data.content[0].name").value("테스트 가게"));
+    }
 
     @Test
     @DisplayName("가게 정보 수정 - Manager1 성공 (200 OK)")


### PR DESCRIPTION
#### 수정 사항
- Store가 BaseEntity를 상속받음
- Store에 Soft Delete 적용
- Store에 삭제된 데이터 필터링 기능 추가
- StoreRepository 쿼리 필터문 추가

#### 테스트 코드
- StoreControllerTest 수정
- StoreServiceTest 작성

#### 버그 픽스
- ReviewRepository, ReviewService: 함수명 변경 `findByStore_StoreIdAndDeletedAtIsNull`
- ReviewResponseDto: `this.storeId = review.getStore().getStoreId();`