### PR TITLE
feat: Order API 및 서비스 로직 구현

### DIFF
--- a/src/main/java/com/team6/backend/order/application/OrderService.java
+++ b/src/main/java/com/team6/backend/order/application/OrderService.java
@@ -15,6 +15,7 @@ import com.team6.backend.order.domain.repository.OrderItemRepository;
 import com.team6.backend.order.domain.repository.OrderRepository;
 import com.team6.backend.order.presentation.dto.OrderCreateRequest;
 import com.team6.backend.order.presentation.dto.OrderResponse;
+import com.team6.backend.order.presentation.dto.OrderStatusUpdate;
 import com.team6.backend.order.presentation.dto.OrderUpdate;
 import com.team6.backend.store.domain.entity.Store;
 import com.team6.backend.store.domain.repository.StoreRepository;
@@ -137,6 +138,20 @@ public class OrderService {
             throw new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND);
     }
 
+    @Transactional
+    public OrderStatusUpdate.Response updateOrderStatus(UUID orderId, OrderStatusUpdate.Request request) {
+        Order order = orderRepository.findById(orderId).orElseThrow(
+                () -> new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND)
+        );
+
+        Role role = securityUtils.getCurrentUserRole();
+        if (role == Role.OWNER && !securityUtils.getCurrentUserId().equals(order.getUser().getId())) {
+            throw new ApplicationException(CommonErrorCode.FORBIDDEN);
+        }
+        order.updateOrderStatus(request.getOrderStatus());
+
+        return OrderStatusUpdate.Response.from(order.getId(), order.getOrderStatus());
+    }
 
 
 }

--- a/src/main/java/com/team6/backend/order/application/OrderService.java
+++ b/src/main/java/com/team6/backend/order/application/OrderService.java
@@ -14,10 +14,13 @@ import com.team6.backend.order.domain.repository.OrderRepository;
 import com.team6.backend.order.domain.entity.Order;
 import com.team6.backend.order.presentation.dto.OrderCreateRequest;
 import com.team6.backend.order.presentation.dto.OrderResponse;
+import com.team6.backend.order.presentation.dto.OrderUpdate;
+import com.team6.backend.order.presentation.dto.OrderUpdateRequest;
 import com.team6.backend.store.domain.entity.Store;
 import com.team6.backend.store.domain.repository.StoreRepository;
 import com.team6.backend.user.domain.entity.Role;
 import com.team6.backend.user.domain.entity.User;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -112,6 +115,14 @@ public class OrderService {
         return OrderResponse.from(order, order.getUser().getId(), orderItems);
     }
 
+    @Transactional
+    public OrderUpdate.Response updateOrder(UUID orderId, @Valid OrderUpdate.Request request) {
+        Order order = orderRepository.findById(orderId).orElseThrow(
+                () -> new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND)
+        );
+        order.updateRequestText(request.getRequestText());
+        return OrderUpdate.Response.from(orderId, request.getRequestText());
+    }
 
 
 

--- a/src/main/java/com/team6/backend/order/application/OrderService.java
+++ b/src/main/java/com/team6/backend/order/application/OrderService.java
@@ -82,7 +82,7 @@ public class OrderService {
         Role role = securityUtils.getCurrentUserRole();
         Page<Order> orders = switch (role) {
             case CUSTOMER -> orderRepository.findAllByUserId(userId, pageable);
-            case OWNER -> orderRepository.findAllByStore_User_Id(userId, pageable);
+            case OWNER -> orderRepository.findAllByStore_OwnerId(userId, pageable);
             case MANAGER, MASTER -> orderRepository.findAll(pageable);
             default -> throw new ApplicationException(CommonErrorCode.FORBIDDEN);
         };
@@ -123,18 +123,6 @@ public class OrderService {
         return OrderUpdate.Response.from(orderId, request.getRequestText());
     }
 
-
-
-    private void validateStoreOrderable(Store store) {
-        if (store.isHidden() || store.isDeleted())
-            throw new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND);
-    }
-
-    private void validateMenuOrderable(Menu menu) {
-        if (menu.isHidden() || menu.isDeleted())
-            throw new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND);
-    }
-
     @Transactional
     public OrderStatusUpdate.Response updateOrderStatus(UUID orderId, OrderStatusUpdate.Request request) {
         Order order = orderRepository.findById(orderId).orElseThrow(
@@ -165,5 +153,15 @@ public class OrderService {
                 () -> new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND)
         );
         order.markDeleted(securityUtils.getCurrentUserId().toString());
+    }
+
+    private void validateStoreOrderable(Store store) {
+        if (store.isHidden() || store.isDeleted())
+            throw new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND);
+    }
+
+    private void validateMenuOrderable(Menu menu) {
+        if (menu.isHidden() || menu.isDeleted())
+            throw new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND);
     }
 }

--- a/src/main/java/com/team6/backend/order/application/OrderService.java
+++ b/src/main/java/com/team6/backend/order/application/OrderService.java
@@ -1,14 +1,20 @@
 package com.team6.backend.order.application;
 
+import com.team6.backend.address.domain.entity.Address;
+import com.team6.backend.address.domain.repository.AddressRepository;
 import com.team6.backend.auth.domain.repository.UserRepository;
 import com.team6.backend.global.infrastructure.exception.ApplicationException;
 import com.team6.backend.global.infrastructure.exception.CommonErrorCode;
+import com.team6.backend.menu.domain.entity.Menu;
+import com.team6.backend.menu.domain.repository.MenuRepository;
 import com.team6.backend.order.domain.entity.OrderItem;
 import com.team6.backend.order.domain.repository.OrderItemRepository;
 import com.team6.backend.order.domain.repository.OrderRepository;
 import com.team6.backend.order.domain.entity.Order;
 import com.team6.backend.order.presentation.dto.OrderCreateRequest;
 import com.team6.backend.order.presentation.dto.OrderResponse;
+import com.team6.backend.store.domain.entity.Store;
+import com.team6.backend.store.domain.repository.StoreRepository;
 import com.team6.backend.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,7 +27,7 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class OrderService {
-    /*
+
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final UserRepository userRepository;
@@ -31,10 +37,12 @@ public class OrderService {
 
     @Transactional
     public OrderResponse createOrder(OrderCreateRequest request, UUID userId) {
+        // 인증된 사용자는 getReferenceById로 참조
         User user = userRepository.getReferenceById(userId);
 
         Store store = storeRepository.findById(request.getStoreId())
                 .orElseThrow(() -> new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND));
+        // 가게 영업 여부 확인
         validateStoreOrderable(store);
 
         Address address = addressRepository.findById(request.getAddressId())
@@ -46,20 +54,25 @@ public class OrderService {
                 itemRequest -> {
                     Menu menu = menuRepository.findById(itemRequest.getMenuId())
                             .orElseThrow(() -> new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND));
+                    // 메뉴 활성화 여부 확인
                     validateMenuOrderable(menu);
                     return OrderItem.createOrderItem(order, menu, itemRequest.getQuantity(), menu.getPrice());
                 }
         ).toList();
 
-        int totalPrice = orderItems.stream()
-                .mapToInt(item -> item.getQuantity() * item.getUnitPrice())
+        Long totalPrice = orderItems.stream()
+                .mapToLong(item -> (long) item.getQuantity() * item.getUnitPrice())
                 .sum();
-        order.updateToTotalPrice(totalPrice);
+        order.updateTotalPrice(totalPrice);
 
         orderRepository.save(order);
         orderItemRepository.saveAll(orderItems);
         return OrderResponse.from(order, userId, orderItems);
     }
+
+
+
+
 
     private void validateStoreOrderable(Store store) {
         if (store.isHidden() || store.isDeleted())
@@ -70,5 +83,5 @@ public class OrderService {
         if (menu.isHidden() || menu.isDeleted())
             throw new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND);
     }
-    */
+
 }

--- a/src/main/java/com/team6/backend/order/application/OrderService.java
+++ b/src/main/java/com/team6/backend/order/application/OrderService.java
@@ -159,5 +159,11 @@ public class OrderService {
         return OrderCancel.Response.from(orderId, order.getOrderStatus());
     }
 
-
+    @Transactional
+    public void deleteOrder(UUID orderId) {
+        Order order = orderRepository.findById(orderId).orElseThrow(
+                () -> new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND)
+        );
+        order.markDeleted(securityUtils.getCurrentUserId().toString());
+    }
 }

--- a/src/main/java/com/team6/backend/order/application/OrderService.java
+++ b/src/main/java/com/team6/backend/order/application/OrderService.java
@@ -8,14 +8,14 @@ import com.team6.backend.global.infrastructure.exception.ApplicationException;
 import com.team6.backend.global.infrastructure.exception.CommonErrorCode;
 import com.team6.backend.menu.domain.entity.Menu;
 import com.team6.backend.menu.domain.repository.MenuRepository;
+import com.team6.backend.order.domain.OrderStatus;
+import com.team6.backend.order.domain.entity.Order;
 import com.team6.backend.order.domain.entity.OrderItem;
 import com.team6.backend.order.domain.repository.OrderItemRepository;
 import com.team6.backend.order.domain.repository.OrderRepository;
-import com.team6.backend.order.domain.entity.Order;
 import com.team6.backend.order.presentation.dto.OrderCreateRequest;
 import com.team6.backend.order.presentation.dto.OrderResponse;
 import com.team6.backend.order.presentation.dto.OrderUpdate;
-import com.team6.backend.order.presentation.dto.OrderUpdateRequest;
 import com.team6.backend.store.domain.entity.Store;
 import com.team6.backend.store.domain.repository.StoreRepository;
 import com.team6.backend.user.domain.entity.Role;
@@ -117,7 +117,8 @@ public class OrderService {
 
     @Transactional
     public OrderUpdate.Response updateOrder(UUID orderId, @Valid OrderUpdate.Request request) {
-        Order order = orderRepository.findById(orderId).orElseThrow(
+        // Order 상태 PENDING 여부 확인
+        Order order = orderRepository.findByIdAndOrderStatus(orderId, OrderStatus.PENDING).orElseThrow(
                 () -> new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND)
         );
         order.updateRequestText(request.getRequestText());

--- a/src/main/java/com/team6/backend/order/application/OrderService.java
+++ b/src/main/java/com/team6/backend/order/application/OrderService.java
@@ -3,6 +3,7 @@ package com.team6.backend.order.application;
 import com.team6.backend.address.domain.entity.Address;
 import com.team6.backend.address.domain.repository.AddressRepository;
 import com.team6.backend.auth.domain.repository.UserRepository;
+import com.team6.backend.global.infrastructure.config.security.util.SecurityUtils;
 import com.team6.backend.global.infrastructure.exception.ApplicationException;
 import com.team6.backend.global.infrastructure.exception.CommonErrorCode;
 import com.team6.backend.menu.domain.entity.Menu;
@@ -39,6 +40,7 @@ public class OrderService {
     private final StoreRepository storeRepository;
     private final MenuRepository menuRepository;
     private final AddressRepository addressRepository;
+    private final SecurityUtils securityUtils;
 
     @Transactional
     public OrderResponse createOrder(OrderCreateRequest request, UUID userId) {
@@ -75,7 +77,8 @@ public class OrderService {
         return OrderResponse.from(order, userId, orderItems);
     }
 
-    public Page<OrderResponse> getOrders(UUID userId, Role role, Pageable pageable) {
+    public Page<OrderResponse> getOrders(UUID userId, Pageable pageable) {
+        Role role = securityUtils.getCurrentUserRole();
         Page<Order> orders = switch (role) {
             case CUSTOMER -> orderRepository.findAllByUserId(userId, pageable);
             case OWNER -> orderRepository.findAllByStore_User_Id(userId, pageable);
@@ -95,6 +98,22 @@ public class OrderService {
         ));
     }
 
+    public OrderResponse getOrder(UUID orderId) {
+        Role role = securityUtils.getCurrentUserRole();
+        Order order = orderRepository.findById(orderId).orElseThrow(
+                () -> new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND)
+        );
+        // 가게에 포함되는 주문 일치 여부 확인
+        if (role == Role.OWNER && !securityUtils.getCurrentUserId().equals(order.getUser().getId())) {
+            throw new ApplicationException(CommonErrorCode.FORBIDDEN);
+        }
+
+        List<OrderItem> orderItems = orderItemRepository.findByOrderId(orderId);
+        return OrderResponse.from(order, order.getUser().getId(), orderItems);
+    }
+
+
+
 
     private void validateStoreOrderable(Store store) {
         if (store.isHidden() || store.isDeleted())
@@ -105,6 +124,7 @@ public class OrderService {
         if (menu.isHidden() || menu.isDeleted())
             throw new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND);
     }
+
 
 
 }

--- a/src/main/java/com/team6/backend/order/application/OrderService.java
+++ b/src/main/java/com/team6/backend/order/application/OrderService.java
@@ -13,10 +13,7 @@ import com.team6.backend.order.domain.entity.Order;
 import com.team6.backend.order.domain.entity.OrderItem;
 import com.team6.backend.order.domain.repository.OrderItemRepository;
 import com.team6.backend.order.domain.repository.OrderRepository;
-import com.team6.backend.order.presentation.dto.OrderCreateRequest;
-import com.team6.backend.order.presentation.dto.OrderResponse;
-import com.team6.backend.order.presentation.dto.OrderStatusUpdate;
-import com.team6.backend.order.presentation.dto.OrderUpdate;
+import com.team6.backend.order.presentation.dto.*;
 import com.team6.backend.store.domain.entity.Store;
 import com.team6.backend.store.domain.repository.StoreRepository;
 import com.team6.backend.user.domain.entity.Role;
@@ -151,6 +148,15 @@ public class OrderService {
         order.updateOrderStatus(request.getOrderStatus());
 
         return OrderStatusUpdate.Response.from(order.getId(), order.getOrderStatus());
+    }
+
+    @Transactional
+    public OrderCancel.Response cancelOrder(UUID orderId) {
+        Order order = orderRepository.findById(orderId).orElseThrow(
+                () -> new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND)
+        );
+        order.updateOrderStatus(OrderStatus.CANCELLED);
+        return OrderCancel.Response.from(orderId, order.getOrderStatus());
     }
 
 

--- a/src/main/java/com/team6/backend/order/application/OrderService.java
+++ b/src/main/java/com/team6/backend/order/application/OrderService.java
@@ -15,13 +15,18 @@ import com.team6.backend.order.presentation.dto.OrderCreateRequest;
 import com.team6.backend.order.presentation.dto.OrderResponse;
 import com.team6.backend.store.domain.entity.Store;
 import com.team6.backend.store.domain.repository.StoreRepository;
+import com.team6.backend.user.domain.entity.Role;
 import com.team6.backend.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -70,8 +75,25 @@ public class OrderService {
         return OrderResponse.from(order, userId, orderItems);
     }
 
+    public Page<OrderResponse> getOrders(UUID userId, Role role, Pageable pageable) {
+        Page<Order> orders = switch (role) {
+            case CUSTOMER -> orderRepository.findAllByUserId(userId, pageable);
+            case OWNER -> orderRepository.findAllByStore_User_Id(userId, pageable);
+            case MANAGER, MASTER -> orderRepository.findAll(pageable);
+            default -> throw new ApplicationException(CommonErrorCode.FORBIDDEN);
+        };
+        // Order 하나에 해당하는 List<OrderItem>를 한번에 불러오기 위한 로직
+        List<UUID> orderIds = orders.getContent().stream().map(Order::getId).toList();
+        // N+1 방지를 위해 조회하려는 Order ID를 리스트로 검색해서 해당하는 List<OrderItem>을 한번에 다 가져와서 그룹핑
+        Map<UUID, List<OrderItem>> orderItemsMap = orderItemRepository.findAllByOrder_IdIn(orderIds)
+                .stream().collect(Collectors.groupingBy(item -> item.getOrder().getId()));
 
-
+        return orders.map(order -> OrderResponse.from(
+                order,
+                userId,
+                orderItemsMap.getOrDefault(order.getId(), List.of())
+        ));
+    }
 
 
     private void validateStoreOrderable(Store store) {
@@ -83,5 +105,6 @@ public class OrderService {
         if (menu.isHidden() || menu.isDeleted())
             throw new ApplicationException(CommonErrorCode.RESOURCE_NOT_FOUND);
     }
+
 
 }

--- a/src/main/java/com/team6/backend/order/domain/entity/Order.java
+++ b/src/main/java/com/team6/backend/order/domain/entity/Order.java
@@ -62,4 +62,5 @@ public class Order extends BaseEntity {
     }
     public void updateTotalPrice(Long totalPrice) {this.totalPrice = totalPrice;}
     public void updateOrderStatus(OrderStatus orderStatus) {this.orderStatus = orderStatus;}
+    public void updateRequestText(String requestText) {this.requestText = requestText;}
 }

--- a/src/main/java/com/team6/backend/order/domain/entity/Order.java
+++ b/src/main/java/com/team6/backend/order/domain/entity/Order.java
@@ -1,6 +1,7 @@
 package com.team6.backend.order.domain.entity;
 
 
+import com.team6.backend.address.domain.entity.Address;
 import com.team6.backend.global.infrastructure.entity.BaseEntity;
 import com.team6.backend.order.domain.OrderStatus;
 import com.team6.backend.store.domain.entity.Store;
@@ -30,11 +31,9 @@ public class Order extends BaseEntity {
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
-    /*
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "address_id", nullable = false)
     private Address address;
-    */
 
     @Column(nullable = false, length = 20)
     private String orderType = "ONLINE";
@@ -48,7 +47,6 @@ public class Order extends BaseEntity {
 
     private String requestText;
 
-    /*
     public static Order createOrder(User user, Store store, Address address, String requestText) {
         Order order = new Order();
         order.user = user;
@@ -57,10 +55,6 @@ public class Order extends BaseEntity {
         order.requestText = requestText;
         return order;
     }
-     */
-
-    public void updateToTotalPrice(Long totalPrice) {
-        this.totalPrice = totalPrice;
-    }
+    public void updateTotalPrice(Long totalPrice) {this.totalPrice = totalPrice;}
     public void updateOrderStatus(OrderStatus orderStatus) {this.orderStatus = orderStatus;}
 }

--- a/src/main/java/com/team6/backend/order/domain/entity/Order.java
+++ b/src/main/java/com/team6/backend/order/domain/entity/Order.java
@@ -47,6 +47,11 @@ public class Order extends BaseEntity {
 
     private String requestText;
 
+    /*
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> orderItems = new ArrayList<>();
+     */
+
     public static Order createOrder(User user, Store store, Address address, String requestText) {
         Order order = new Order();
         order.user = user;

--- a/src/main/java/com/team6/backend/order/domain/entity/OrderItem.java
+++ b/src/main/java/com/team6/backend/order/domain/entity/OrderItem.java
@@ -1,6 +1,7 @@
 package com.team6.backend.order.domain.entity;
 
 import com.team6.backend.global.infrastructure.entity.BaseEntity;
+import com.team6.backend.menu.domain.entity.Menu;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -23,7 +24,6 @@ public class OrderItem extends BaseEntity {
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
 
-    /*
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "menu_id", nullable = false)
     private Menu menu;
@@ -42,5 +42,4 @@ public class OrderItem extends BaseEntity {
         orderItem.unitPrice = unitPrice;
         return orderItem;
     }
-     */
 }

--- a/src/main/java/com/team6/backend/order/domain/repository/OrderItemRepository.java
+++ b/src/main/java/com/team6/backend/order/domain/repository/OrderItemRepository.java
@@ -1,9 +1,17 @@
 package com.team6.backend.order.domain.repository;
 
+import com.team6.backend.order.domain.entity.Order;
 import com.team6.backend.order.domain.entity.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface OrderItemRepository extends JpaRepository<OrderItem, UUID> {
+    List<OrderItem> findByOrderId(UUID orderId);
+
+    Map<UUID, List<OrderItem>> findAllByOrderIn(Collection<Order> orders);
+    List<OrderItem> findAllByOrder_IdIn(List<UUID> orderIds);
 }

--- a/src/main/java/com/team6/backend/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/team6/backend/order/domain/repository/OrderRepository.java
@@ -12,5 +12,5 @@ import java.util.UUID;
 public interface OrderRepository extends JpaRepository<Order, UUID> {
     Optional<Order> findByIdAndOrderStatus(UUID orderId, OrderStatus orderStatus);
     Page<Order> findAllByUserId(UUID userId, Pageable pageable);
-    Page<Order> findAllByStore_User_Id(UUID userId, Pageable pageable);
+    Page<Order> findAllByStore_OwnerId(UUID storeOwnerId, Pageable pageable);
 }

--- a/src/main/java/com/team6/backend/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/team6/backend/order/domain/repository/OrderRepository.java
@@ -2,8 +2,6 @@ package com.team6.backend.order.domain.repository;
 
 import com.team6.backend.order.domain.OrderStatus;
 import com.team6.backend.order.domain.entity.Order;
-import com.team6.backend.order.presentation.dto.OrderResponse;
-import org.aspectj.weaver.ast.Or;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/team6/backend/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/team6/backend/order/domain/repository/OrderRepository.java
@@ -1,9 +1,15 @@
 package com.team6.backend.order.domain.repository;
 
 import com.team6.backend.order.domain.entity.Order;
+import com.team6.backend.order.presentation.dto.OrderResponse;
+import org.aspectj.weaver.ast.Or;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
+    Page<Order> findAllByUserId(UUID userId, Pageable pageable);
+    Page<Order> findAllByStore_User_Id(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/team6/backend/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/team6/backend/order/domain/repository/OrderRepository.java
@@ -1,5 +1,6 @@
 package com.team6.backend.order.domain.repository;
 
+import com.team6.backend.order.domain.OrderStatus;
 import com.team6.backend.order.domain.entity.Order;
 import com.team6.backend.order.presentation.dto.OrderResponse;
 import org.aspectj.weaver.ast.Or;
@@ -7,9 +8,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
+    Optional<Order> findByIdAndOrderStatus(UUID orderId, OrderStatus orderStatus);
     Page<Order> findAllByUserId(UUID userId, Pageable pageable);
     Page<Order> findAllByStore_User_Id(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/team6/backend/order/presentation/OrderController.java
+++ b/src/main/java/com/team6/backend/order/presentation/OrderController.java
@@ -5,7 +5,7 @@ import com.team6.backend.global.infrastructure.response.SuccessResponse;
 import com.team6.backend.order.application.OrderService;
 import com.team6.backend.order.presentation.dto.OrderCreateRequest;
 import com.team6.backend.order.presentation.dto.OrderResponse;
-import com.team6.backend.user.domain.entity.Role;
+import com.team6.backend.order.presentation.dto.OrderUpdate;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -46,6 +46,14 @@ public class OrderController {
     public ResponseEntity<SuccessResponse<OrderResponse>> getOrder(@PathVariable UUID orderId) {
         return ResponseEntity.ok(SuccessResponse.ok(orderService.getOrder(orderId)));
     }
+
+    @PutMapping("/orders/{orderId}")
+    @PreAuthorize("hasAnyRole('CUSTOMER')")
+    public ResponseEntity<SuccessResponse<OrderUpdate.Response>> updateOrder(@PathVariable UUID orderId,
+                                                                      @RequestBody @Valid OrderUpdate.Request request) {
+        return ResponseEntity.ok(SuccessResponse.ok(orderService.updateOrder(orderId, request)));
+    }
+
 
 
 

--- a/src/main/java/com/team6/backend/order/presentation/OrderController.java
+++ b/src/main/java/com/team6/backend/order/presentation/OrderController.java
@@ -3,10 +3,7 @@ package com.team6.backend.order.presentation;
 import com.team6.backend.global.infrastructure.config.security.util.SecurityUtils;
 import com.team6.backend.global.infrastructure.response.SuccessResponse;
 import com.team6.backend.order.application.OrderService;
-import com.team6.backend.order.presentation.dto.OrderCreateRequest;
-import com.team6.backend.order.presentation.dto.OrderResponse;
-import com.team6.backend.order.presentation.dto.OrderStatusUpdate;
-import com.team6.backend.order.presentation.dto.OrderUpdate;
+import com.team6.backend.order.presentation.dto.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -63,6 +60,16 @@ public class OrderController {
     ) {
         return ResponseEntity.ok(
                 SuccessResponse.ok(orderService.updateOrderStatus(orderId, request))
+        );
+    }
+
+    @PatchMapping("/orders/{orderId}/cancel")
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'MASTER')")
+    public ResponseEntity<SuccessResponse<OrderCancel.Response>> cancelOrder(
+            @PathVariable UUID orderId
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.ok(orderService.cancelOrder(orderId))
         );
     }
 

--- a/src/main/java/com/team6/backend/order/presentation/OrderController.java
+++ b/src/main/java/com/team6/backend/order/presentation/OrderController.java
@@ -1,5 +1,6 @@
 package com.team6.backend.order.presentation;
 
+import com.team6.backend.global.infrastructure.response.SuccessResponse;
 import com.team6.backend.order.application.OrderService;
 import com.team6.backend.order.presentation.dto.OrderCreateRequest;
 import com.team6.backend.order.presentation.dto.OrderResponse;
@@ -22,12 +23,13 @@ public class OrderController {
 
     private final OrderService orderService;
 
-    /*
     @PostMapping("/orders")
     @PreAuthorize("hasAnyRole('CUSTOMER')")
-    public ResponseEntity<OrderResponse> createOrder(@RequestBody @Valid OrderCreateRequest request,
-                                                     @AuthenticationPrincipal UUID userId) {
-        return ResponseEntity.ok().body(orderService.createOrder(request, userId));
+    public ResponseEntity<SuccessResponse<OrderResponse>> createOrder(@RequestBody @Valid OrderCreateRequest request,
+                                                                     @AuthenticationPrincipal UUID userId) {
+        return ResponseEntity.ok(SuccessResponse.created(orderService.createOrder(request, userId)));
     }
-     */
+
+
+
 }

--- a/src/main/java/com/team6/backend/order/presentation/OrderController.java
+++ b/src/main/java/com/team6/backend/order/presentation/OrderController.java
@@ -1,18 +1,21 @@
 package com.team6.backend.order.presentation;
 
+import com.team6.backend.global.infrastructure.config.security.util.SecurityUtils;
 import com.team6.backend.global.infrastructure.response.SuccessResponse;
 import com.team6.backend.order.application.OrderService;
 import com.team6.backend.order.presentation.dto.OrderCreateRequest;
 import com.team6.backend.order.presentation.dto.OrderResponse;
+import com.team6.backend.user.domain.entity.Role;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -22,6 +25,7 @@ import java.util.UUID;
 public class OrderController {
 
     private final OrderService orderService;
+    private final SecurityUtils securityUtils;
 
     @PostMapping("/orders")
     @PreAuthorize("hasAnyRole('CUSTOMER')")
@@ -30,6 +34,14 @@ public class OrderController {
         return ResponseEntity.ok(SuccessResponse.created(orderService.createOrder(request, userId)));
     }
 
+    @GetMapping("/orders")
+    public ResponseEntity<SuccessResponse<Page<OrderResponse>>> getOrders(
+            @AuthenticationPrincipal UUID userId,
+            @PageableDefault(size = 10, sort = "createdBy", direction = Sort.Direction.DESC)
+            Pageable pageable) {
+        Role role = securityUtils.getCurrentUserRole();
+        return ResponseEntity.ok(SuccessResponse.ok(orderService.getOrders(userId, role, pageable)));
+    }
 
 
 }

--- a/src/main/java/com/team6/backend/order/presentation/OrderController.java
+++ b/src/main/java/com/team6/backend/order/presentation/OrderController.java
@@ -39,9 +39,15 @@ public class OrderController {
             @AuthenticationPrincipal UUID userId,
             @PageableDefault(size = 10, sort = "createdBy", direction = Sort.Direction.DESC)
             Pageable pageable) {
-        Role role = securityUtils.getCurrentUserRole();
-        return ResponseEntity.ok(SuccessResponse.ok(orderService.getOrders(userId, role, pageable)));
+        return ResponseEntity.ok(SuccessResponse.ok(orderService.getOrders(userId, pageable)));
+    }
+
+    @GetMapping("/orders/{orderId}")
+    public ResponseEntity<SuccessResponse<OrderResponse>> getOrder(@PathVariable UUID orderId) {
+        return ResponseEntity.ok(SuccessResponse.ok(orderService.getOrder(orderId)));
     }
 
 
+
 }
+

--- a/src/main/java/com/team6/backend/order/presentation/OrderController.java
+++ b/src/main/java/com/team6/backend/order/presentation/OrderController.java
@@ -73,8 +73,11 @@ public class OrderController {
         );
     }
 
-
-
-
+    @DeleteMapping("/orders/{orderId}")
+    @PreAuthorize("hasRole('MASTER')")
+    public ResponseEntity<Void> deleteOrder(@PathVariable UUID orderId) {
+        orderService.deleteOrder(orderId);
+        return ResponseEntity.noContent().build();
+    }
 }
 

--- a/src/main/java/com/team6/backend/order/presentation/OrderController.java
+++ b/src/main/java/com/team6/backend/order/presentation/OrderController.java
@@ -5,6 +5,7 @@ import com.team6.backend.global.infrastructure.response.SuccessResponse;
 import com.team6.backend.order.application.OrderService;
 import com.team6.backend.order.presentation.dto.OrderCreateRequest;
 import com.team6.backend.order.presentation.dto.OrderResponse;
+import com.team6.backend.order.presentation.dto.OrderStatusUpdate;
 import com.team6.backend.order.presentation.dto.OrderUpdate;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -52,6 +53,17 @@ public class OrderController {
     public ResponseEntity<SuccessResponse<OrderUpdate.Response>> updateOrder(@PathVariable UUID orderId,
                                                                       @RequestBody @Valid OrderUpdate.Request request) {
         return ResponseEntity.ok(SuccessResponse.ok(orderService.updateOrder(orderId, request)));
+    }
+
+    @PatchMapping("/orders/{orderId}/status")
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
+    public ResponseEntity<SuccessResponse<OrderStatusUpdate.Response>> updateOrderStatus(
+            @PathVariable UUID orderId,
+            @RequestBody @Valid OrderStatusUpdate.Request request
+    ) {
+        return ResponseEntity.ok(
+                SuccessResponse.ok(orderService.updateOrderStatus(orderId, request))
+        );
     }
 
 

--- a/src/main/java/com/team6/backend/order/presentation/dto/OrderCancel.java
+++ b/src/main/java/com/team6/backend/order/presentation/dto/OrderCancel.java
@@ -1,0 +1,25 @@
+package com.team6.backend.order.presentation.dto;
+
+import com.team6.backend.order.domain.OrderStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+public final class OrderCancel {
+
+    private OrderCancel() {
+    }
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Response {
+        private UUID orderId;
+        private OrderStatus orderStatus;
+
+        public static Response from(UUID orderId, OrderStatus orderStatus) {
+            return new Response(orderId, orderStatus);
+        }
+    }
+}

--- a/src/main/java/com/team6/backend/order/presentation/dto/OrderCreateRequest.java
+++ b/src/main/java/com/team6/backend/order/presentation/dto/OrderCreateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,7 +12,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderCreateRequest {
     @NotNull
     private UUID storeId;

--- a/src/main/java/com/team6/backend/order/presentation/dto/OrderItemResponse.java
+++ b/src/main/java/com/team6/backend/order/presentation/dto/OrderItemResponse.java
@@ -18,16 +18,13 @@ public class OrderItemResponse {
     private final Integer quantity;
     private final Integer unitPrice;
 
-    /*
     public static OrderItemResponse from(OrderItem orderItem) {
         return OrderItemResponse.builder()
                 .orderItemId(orderItem.getId())
                 .orderId(orderItem.getOrder().getId())
-                .menuId(orderItem.getMenu().getId())
+                .menuId(orderItem.getMenu().getMenuId())
                 .quantity(orderItem.getQuantity())
                 .unitPrice(orderItem.getUnitPrice())
                 .build();
     }
-     */
-
 }

--- a/src/main/java/com/team6/backend/order/presentation/dto/OrderResponse.java
+++ b/src/main/java/com/team6/backend/order/presentation/dto/OrderResponse.java
@@ -17,23 +17,20 @@ public class OrderResponse {
     private final UUID userId;
     private final UUID storeId;
     private final UUID addressId;
-    private final Integer totalPrice;
+    private final Long totalPrice;
     private final String requestText;
     private final List<OrderItemResponse> items;
 
-    /*
     public static OrderResponse from(Order order, UUID userId, List<OrderItem> orderItems) {
-        return OrderResponse.builder()
-                .orderId(order.getId())
-                .userId(userId)
-                .storeId(order.getStore().getId())
-                .addressId(order.getAddress().getId())
-                .totalPrice(order.getTotalPrice())
-                .requestText(order.getRequestText())
-                .items(orderItems.stream()
+        return new OrderResponse(
+                order.getId(),
+                userId,
+                order.getStore().getStoreId(),
+                order.getAddress().getAdId(),
+                order.getTotalPrice(),
+                order.getRequestText(),
+                orderItems.stream()
                         .map(OrderItemResponse::from)
-                        .toList())
-                .build();
+                        .toList());
     }
-     */
 }

--- a/src/main/java/com/team6/backend/order/presentation/dto/OrderResponse.java
+++ b/src/main/java/com/team6/backend/order/presentation/dto/OrderResponse.java
@@ -4,7 +4,6 @@ import com.team6.backend.order.domain.entity.Order;
 import com.team6.backend.order.domain.entity.OrderItem;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;

--- a/src/main/java/com/team6/backend/order/presentation/dto/OrderStatusUpdate.java
+++ b/src/main/java/com/team6/backend/order/presentation/dto/OrderStatusUpdate.java
@@ -1,0 +1,35 @@
+package com.team6.backend.order.presentation.dto;
+
+import com.team6.backend.order.domain.OrderStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+public final class OrderStatusUpdate {
+
+    private OrderStatusUpdate() {
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Request {
+
+        @NotNull
+        private OrderStatus orderStatus;
+    }
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Response {
+        private UUID orderId;
+        private OrderStatus orderStatus;
+
+        public static Response from(UUID orderId, OrderStatus orderStatus) {
+            return new Response(orderId, orderStatus);
+        }
+    }
+}

--- a/src/main/java/com/team6/backend/order/presentation/dto/OrderUpdate.java
+++ b/src/main/java/com/team6/backend/order/presentation/dto/OrderUpdate.java
@@ -1,0 +1,35 @@
+package com.team6.backend.order.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+public final class OrderUpdate {
+    private OrderUpdate() {}
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Request {
+
+        @NotBlank
+        @Size(max = 255)
+        private String requestText;
+    }
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Response {
+        private UUID orderId;
+        private String requestText;
+
+        public static Response from(UUID orderId, String requestText) {
+            return new Response(orderId, requestText);
+        }
+    }
+}

--- a/src/main/java/com/team6/backend/order/presentation/dto/OrderUpdate.java
+++ b/src/main/java/com/team6/backend/order/presentation/dto/OrderUpdate.java
@@ -1,7 +1,6 @@
 package com.team6.backend.order.presentation.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/team6/backend/payment/application/PaymentService.java
+++ b/src/main/java/com/team6/backend/payment/application/PaymentService.java
@@ -17,7 +17,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -51,17 +50,15 @@ public class PaymentService {
     }
 
     public Page<PaymentResponse> getPayments(UUID userId, Role role, Pageable pageable) {
-        // 유저 본인 결제 내역 조회
-        if (role == Role.CUSTOMER) {
-            return paymentRepository.findAllByOrder_User_Id(userId, pageable)
+        return switch (role) {
+            // 유저 본인 결제 내역 조회
+            case CUSTOMER -> paymentRepository.findAllByOrder_User_Id(userId, pageable)
                     .map(PaymentResponse::from);
-        }
-        // 전체 결제 내역 조회
-        if (role == Role.MANAGER || role == Role.MASTER) {
-            return paymentRepository.findAll(pageable)
+            // 전체 결제 내역 조회
+            case MANAGER, MASTER -> paymentRepository.findAll(pageable)
                     .map(PaymentResponse::from);
-        }
-        throw new ApplicationException(CommonErrorCode.FORBIDDEN);
+            default -> throw new ApplicationException(CommonErrorCode.FORBIDDEN);
+        };
     }
 
     public PaymentResponse getPayment(UUID paymentId) {

--- a/src/main/java/com/team6/backend/payment/presetation/PaymentController.java
+++ b/src/main/java/com/team6/backend/payment/presetation/PaymentController.java
@@ -5,7 +5,6 @@ import com.team6.backend.global.infrastructure.response.SuccessResponse;
 import com.team6.backend.payment.application.PaymentService;
 import com.team6.backend.payment.presetation.dto.PaymentConfirmRequest;
 import com.team6.backend.payment.presetation.dto.PaymentResponse;
-import com.team6.backend.user.domain.entity.Role;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,7 +16,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -38,7 +36,7 @@ public class PaymentController {
     @PreAuthorize("hasAnyRole('CUSTOMER', 'MANAGER', 'MASTER')")
     public ResponseEntity<SuccessResponse<Page<PaymentResponse>>> getPayments(
             @PageableDefault(size = 10, sort = "createdBy", direction = Sort.Direction.DESC)
-            Pageable pageable, Sort sort) {
+            Pageable pageable) {
         return ResponseEntity.ok(SuccessResponse.ok(paymentService.getPayments(
                 securityUtils.getCurrentUserId(),
                 securityUtils.getCurrentUserRole(),


### PR DESCRIPTION
- 수정/삭제의 응답으로 List<OrderItem>을 담고있는 OrderResponse를 반환하기에는 무거워서 각각 이너클래스로 생성
- 주문 내역 조회 시 List<OrderItem>N+1 방지를 위해 주문 ID 리스트를 통한 전부 조회