### PR TITLE
refactor: 도메인별 에러코드를 도메인 하위 구조로 변경 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ src/main/java/com/team6/backend
     │   └── service
     ├── domain
     │   ├── entity
+    │   ├── exception
     │   └── repository
     └── presentation
         ├── controller

--- a/src/main/java/com/team6/backend/address/application/service/AddressService.java
+++ b/src/main/java/com/team6/backend/address/application/service/AddressService.java
@@ -7,8 +7,6 @@ import com.team6.backend.address.presentation.dto.AddressResponse;
 import com.team6.backend.global.infrastructure.config.security.util.SecurityUtils;
 import com.team6.backend.global.infrastructure.exception.ApplicationException;
 import com.team6.backend.global.infrastructure.exception.CommonErrorCode;
-import com.team6.backend.global.infrastructure.exception.ErrorCode;
-import com.team6.backend.global.infrastructure.exception.StoreErrorCode;
 import com.team6.backend.user.domain.entity.User;
 import com.team6.backend.user.domain.repository.userInfoRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/team6/backend/category/application/service/CategoryService.java
+++ b/src/main/java/com/team6/backend/category/application/service/CategoryService.java
@@ -6,7 +6,7 @@ import com.team6.backend.category.presentation.dto.request.CategoryRequest;
 import com.team6.backend.category.presentation.dto.response.CategoryResponse;
 import com.team6.backend.global.infrastructure.config.security.util.SecurityUtils;
 import com.team6.backend.global.infrastructure.exception.ApplicationException;
-import com.team6.backend.global.infrastructure.exception.CategoryErrorCode;
+import com.team6.backend.category.domain.exception.CategoryErrorCode;
 import com.team6.backend.global.infrastructure.util.AuthValidator;
 import com.team6.backend.user.domain.entity.Role;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/team6/backend/category/domain/exception/CategoryErrorCode.java
+++ b/src/main/java/com/team6/backend/category/domain/exception/CategoryErrorCode.java
@@ -1,5 +1,6 @@
-package com.team6.backend.global.infrastructure.exception;
+package com.team6.backend.category.domain.exception;
 
+import com.team6.backend.global.infrastructure.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/team6/backend/menu/application/service/MenuService.java
+++ b/src/main/java/com/team6/backend/menu/application/service/MenuService.java
@@ -2,7 +2,7 @@ package com.team6.backend.menu.application.service;
 
 import com.team6.backend.global.infrastructure.config.security.util.SecurityUtils;
 import com.team6.backend.global.infrastructure.exception.ApplicationException;
-import com.team6.backend.global.infrastructure.exception.MenuErrorCode;
+import com.team6.backend.menu.domain.exception.MenuErrorCode;
 import com.team6.backend.global.infrastructure.util.AuthValidator;
 import com.team6.backend.menu.domain.entity.Menu;
 import com.team6.backend.menu.domain.repository.MenuRepository;

--- a/src/main/java/com/team6/backend/menu/domain/exception/MenuErrorCode.java
+++ b/src/main/java/com/team6/backend/menu/domain/exception/MenuErrorCode.java
@@ -1,5 +1,6 @@
-package com.team6.backend.global.infrastructure.exception;
+package com.team6.backend.menu.domain.exception;
 
+import com.team6.backend.global.infrastructure.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/team6/backend/store/application/service/StoreService.java
+++ b/src/main/java/com/team6/backend/store/application/service/StoreService.java
@@ -2,7 +2,7 @@ package com.team6.backend.store.application.service;
 
 import com.team6.backend.global.infrastructure.config.security.util.SecurityUtils;
 import com.team6.backend.global.infrastructure.exception.ApplicationException;
-import com.team6.backend.global.infrastructure.exception.StoreErrorCode;
+import com.team6.backend.store.domain.exception.StoreErrorCode;
 import com.team6.backend.global.infrastructure.util.AuthValidator;
 import com.team6.backend.store.domain.entity.Store;
 import com.team6.backend.store.domain.repository.StoreRepository;

--- a/src/main/java/com/team6/backend/store/domain/exception/StoreErrorCode.java
+++ b/src/main/java/com/team6/backend/store/domain/exception/StoreErrorCode.java
@@ -1,5 +1,6 @@
-package com.team6.backend.global.infrastructure.exception;
+package com.team6.backend.store.domain.exception;
 
+import com.team6.backend.global.infrastructure.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/test/java/com/team6/backend/category/application/service/CategoryServiceTest.java
+++ b/src/test/java/com/team6/backend/category/application/service/CategoryServiceTest.java
@@ -6,7 +6,7 @@ import com.team6.backend.category.presentation.dto.request.CategoryRequest;
 import com.team6.backend.category.presentation.dto.response.CategoryResponse;
 import com.team6.backend.global.infrastructure.config.security.util.SecurityUtils;
 import com.team6.backend.global.infrastructure.exception.ApplicationException;
-import com.team6.backend.global.infrastructure.exception.CategoryErrorCode;
+import com.team6.backend.category.domain.exception.CategoryErrorCode;
 import com.team6.backend.global.infrastructure.util.AuthValidator;
 import com.team6.backend.user.domain.entity.Role;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/team6/backend/menu/application/service/MenuServiceTest.java
+++ b/src/test/java/com/team6/backend/menu/application/service/MenuServiceTest.java
@@ -2,8 +2,8 @@ package com.team6.backend.menu.application.service;
 
 import com.team6.backend.global.infrastructure.config.security.util.SecurityUtils;
 import com.team6.backend.global.infrastructure.exception.ApplicationException;
-import com.team6.backend.global.infrastructure.exception.MenuErrorCode;
-import com.team6.backend.global.infrastructure.exception.StoreErrorCode;
+import com.team6.backend.menu.domain.exception.MenuErrorCode;
+import com.team6.backend.store.domain.exception.StoreErrorCode;
 import com.team6.backend.global.infrastructure.util.AuthValidator;
 import com.team6.backend.menu.domain.entity.Menu;
 import com.team6.backend.menu.domain.repository.MenuRepository;

--- a/src/test/java/com/team6/backend/store/application/service/StoreServiceTest.java
+++ b/src/test/java/com/team6/backend/store/application/service/StoreServiceTest.java
@@ -3,7 +3,7 @@ package com.team6.backend.store.application.service;
 import com.team6.backend.global.infrastructure.config.security.util.SecurityUtils;
 import com.team6.backend.global.infrastructure.exception.ApplicationException;
 import com.team6.backend.global.infrastructure.exception.CommonErrorCode;
-import com.team6.backend.global.infrastructure.exception.StoreErrorCode;
+import com.team6.backend.store.domain.exception.StoreErrorCode;
 import com.team6.backend.global.infrastructure.util.AuthValidator;
 import com.team6.backend.store.domain.entity.Store;
 import com.team6.backend.store.domain.repository.StoreRepository;


### PR DESCRIPTION
도메인별 에러코드 파일을 `{도메인명}.domain.exception` 패키지를 만들어서 이동했습니다.
- CategoryErrorCode
- MenuErrorCode
- ServiceErrorCode

---

Issue #39 