### PR TITLE
chore: 누락된 @Valid 어노테이션 추가 및 잘못 설정된 권한 방어 로직 수정

### DIFF
--- a/src/main/java/com/team6/backend/menu/presentation/controller/MenuController.java
+++ b/src/main/java/com/team6/backend/menu/presentation/controller/MenuController.java
@@ -57,7 +57,7 @@ public class MenuController {
     /* 메뉴 수정 */
     @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
     @PutMapping("/menus/{menuId}")
-    public ResponseEntity<SuccessResponse<MenuResponse>> updateMenu(@PathVariable UUID menuId, @RequestBody UpdateMenuRequest request) {
+    public ResponseEntity<SuccessResponse<MenuResponse>> updateMenu(@PathVariable UUID menuId, @RequestBody @Valid UpdateMenuRequest request) {
         MenuResponse response = menuService.updateMenu(menuId, request);
         SuccessResponse successResponse = SuccessResponse.of(CommonSuccessCode.OK, "메뉴 정보 수정이 완료되었습니다.", response);
         return ResponseEntity.ok(successResponse);

--- a/src/main/java/com/team6/backend/menu/presentation/dto/request/MenuRequest.java
+++ b/src/main/java/com/team6/backend/menu/presentation/dto/request/MenuRequest.java
@@ -14,7 +14,7 @@ public class MenuRequest {
     private String name;
 
     @NotNull(message = "가격은 필수입니다.")
-    private int price;
+    private Integer price;
 
     private String description;
 

--- a/src/main/java/com/team6/backend/menu/presentation/dto/request/UpdateMenuRequest.java
+++ b/src/main/java/com/team6/backend/menu/presentation/dto/request/UpdateMenuRequest.java
@@ -13,7 +13,7 @@ public class UpdateMenuRequest {
     private String name;
 
     @NotNull(message = "가격은 필수입니다.")
-    private int price;
+    private Integer price;
 
     private String description;
 

--- a/src/main/java/com/team6/backend/store/application/service/StoreService.java
+++ b/src/main/java/com/team6/backend/store/application/service/StoreService.java
@@ -58,9 +58,9 @@ public class StoreService {
     public StoreResponse updateStore(UUID storeId, StoreRequest request) {
         Store store = findStoreById(storeId);
         authValidator.validateAccess(
-                null,
-                List.of(Role.MASTER, Role.MANAGER, Role.OWNER), // 무조건 허용
-                null, // 조건부 허용
+                store.getOwnerId(),
+                List.of(Role.MASTER, Role.MANAGER),
+                List.of(Role.OWNER),
                 StoreErrorCode.STORE_FORBIDDEN
         );
         store.update(request.getCategoryId(), request.getAreaId(), request.getName(), request.getAddress());
@@ -83,9 +83,9 @@ public class StoreService {
     public StoreResponse hideStore(UUID storeId) {
         Store store = findStoreById(storeId);
         authValidator.validateAccess(
-                null,
-                List.of(Role.MASTER, Role.MANAGER, Role.OWNER),
-                null,
+                store.getOwnerId(),
+                List.of(Role.MASTER, Role.MANAGER),
+                List.of(Role.OWNER),
                 StoreErrorCode.STORE_FORBIDDEN
         );
         store.hideStore();

--- a/src/main/java/com/team6/backend/store/presentation/controller/StoreController.java
+++ b/src/main/java/com/team6/backend/store/presentation/controller/StoreController.java
@@ -5,6 +5,7 @@ import com.team6.backend.global.infrastructure.response.SuccessResponse;
 import com.team6.backend.store.application.service.StoreService;
 import com.team6.backend.store.presentation.dto.request.StoreRequest;
 import com.team6.backend.store.presentation.dto.response.StoreResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +25,7 @@ public class StoreController {
     /* 가게 생성 */
     @PostMapping
     @PreAuthorize("hasRole('OWNER')") // Role이 OWNER인 사용자만 호출 가능
-    public ResponseEntity<SuccessResponse<StoreResponse>> createStore(@RequestBody StoreRequest request) {
+    public ResponseEntity<SuccessResponse<StoreResponse>> createStore(@RequestBody @Valid StoreRequest request) {
         StoreResponse response = storeService.createStore(request);
         URI uri = URI.create("/api/v1/stores/" + response.getStoreId());
         SuccessResponse successResponse = SuccessResponse.of(CommonSuccessCode.CREATED, "가게 생성이 완료되었습니다.", response);
@@ -56,7 +57,7 @@ public class StoreController {
     /* 가게 정보 수정 */
     @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
     @PutMapping("/{storeId}")
-    public ResponseEntity<SuccessResponse<StoreResponse>> updateStore(@PathVariable UUID storeId, @RequestBody StoreRequest request) {
+    public ResponseEntity<SuccessResponse<StoreResponse>> updateStore(@PathVariable UUID storeId, @RequestBody @Valid StoreRequest request) {
         StoreResponse response = storeService.updateStore(storeId, request);
         SuccessResponse successResponse = SuccessResponse.of(CommonSuccessCode.OK, "가게 정보 수정이 완료되었습니다.", response);
         return ResponseEntity.ok(successResponse);

--- a/src/test/java/com/team6/backend/menu/presentation/controller/MenuControllerTest.java
+++ b/src/test/java/com/team6/backend/menu/presentation/controller/MenuControllerTest.java
@@ -247,4 +247,56 @@ class MenuControllerTest {
                         .with(csrf()))
                 .andExpect(status().isForbidden());
     }
+
+    @Test
+    @DisplayName("메뉴 생성 실패 - Validation 에러 (가격 누락)")
+    @WithMockUser(username = "owner1", roles = "OWNER")
+    void createMenu_Fail_Validation_NullPrice() throws Exception {
+        Map<String, Object> request = new HashMap<>();
+        request.put("name", "테스트 메뉴");
+        // price를 의도적으로 누락
+        request.put("aiDescription", false);
+
+        mockMvc.perform(post("/api/v1/stores/{storeId}/menus", storeId)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON_400"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("가격은 필수입니다.")));
+    }
+
+    @Test
+    @DisplayName("메뉴 수정 실패 - Validation 에러 (이름이 공백)")
+    @WithMockUser(username = "manager1", roles = "MANAGER")
+    void updateMenu_Fail_Validation_BlankName() throws Exception {
+        Map<String, Object> request = new HashMap<>();
+        request.put("name", "   "); // 공백 문자열
+        request.put("price", 15000);
+
+        mockMvc.perform(put("/api/v1/menus/{menuId}", menuId)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON_400"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("메뉴 이름은 필수입니다.")));
+    }
+
+    @Test
+    @DisplayName("메뉴 수정 실패 - Validation 에러 (가격 누락)")
+    @WithMockUser(username = "master1", roles = "MASTER")
+    void updateMenu_Fail_Validation_NullPrice() throws Exception {
+        Map<String, Object> request = new HashMap<>();
+        request.put("name", "수정된 메뉴");
+        // price 의도적 누락
+
+        mockMvc.perform(put("/api/v1/menus/{menuId}", menuId)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON_400"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("가격은 필수입니다.")));
+    }
 }

--- a/src/test/java/com/team6/backend/store/presentation/controller/StoreControllerTest.java
+++ b/src/test/java/com/team6/backend/store/presentation/controller/StoreControllerTest.java
@@ -173,4 +173,68 @@ class StoreControllerTest {
                         .with(csrf()))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    @DisplayName("가게 생성 실패 - Validation 에러 (가게 이름 공백)")
+    @WithMockUser(username = "owner1", roles = "OWNER")
+    void createStore_Fail_Validation_BlankName() throws Exception {
+        Map<String, Object> invalidRequest = new HashMap<>(storeRequestMap);
+        invalidRequest.put("name", "   "); // 공백
+
+        mockMvc.perform(post("/api/v1/stores")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON_400"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("가게 이름은 필수입니다.")));
+    }
+
+    @Test
+    @DisplayName("가게 생성 실패 - Validation 에러 (카테고리 ID 누락)")
+    @WithMockUser(username = "owner1", roles = "OWNER")
+    void createStore_Fail_Validation_NullCategoryId() throws Exception {
+        Map<String, Object> invalidRequest = new HashMap<>(storeRequestMap);
+        invalidRequest.remove("categoryId"); // ID 누락
+
+        mockMvc.perform(post("/api/v1/stores")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON_400"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("카테고리 ID는 필수입니다.")));
+    }
+
+    @Test
+    @DisplayName("가게 생성 실패 - Validation 에러 (주소 공백)")
+    @WithMockUser(username = "owner1", roles = "OWNER")
+    void createStore_Fail_Validation_BlankAddress() throws Exception {
+        Map<String, Object> invalidRequest = new HashMap<>(storeRequestMap);
+        invalidRequest.put("address", ""); // 공백 주소
+
+        mockMvc.perform(post("/api/v1/stores")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON_400"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("가게 주소는 필수입니다.")));
+    }
+
+    @Test
+    @DisplayName("가게 수정 실패 - Validation 에러 (지역 ID 누락)")
+    @WithMockUser(username = "manager1", roles = "MANAGER")
+    void updateStore_Fail_Validation_NullAreaId() throws Exception {
+        Map<String, Object> invalidRequest = new HashMap<>(storeRequestMap);
+        invalidRequest.remove("areaId"); // 지역 ID 누락
+
+        mockMvc.perform(put("/api/v1/stores/{storeId}", storeId)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON_400"))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("지역 ID는 필수입니다.")));
+    }
 }


### PR DESCRIPTION
### 수정 사항
- `StoreController` / `MenuController` : 누락된 `@Valid` 어노테이션 추가
- `StoreService` : 잘못 설정된 권한 방어 로직 수정
- `StoreControllerTest` / `MenuControllerTest` : `@Valid` 관련 테스트 코드 추가
- `MenuRequest` / `UpdateMenuRequest` : `int` 자료형을 `Integer`로 변경

---

### 트러블 슈팅

#### Problems
아래 두 테스트가 통과되지 않는 문제가 발생했습니다.
- `createMenu_Fail_Validation_NullPrice()` 실패: Expected 400, but 500
- `updateMenu_Fail_Validation_NullPrice()` 실패: Expected 400, but 200

#### Causes
테스트 실패 원인은 `MenuRequest`와 `UpdateMenuRequest` DTO 클래스에서 `price` 필드의 타입이 원시 타입인 `int`로 선언되어 있기 때문이었습니다.
- `int`는 `null`이 될 수 없습니다. JSON 요청에서 `price`가 누락되면 Jackson은 기본적으로 `price`를 0으로 채워 넣습니다.
- 값이 0으로 설정되므로 Spring의 `@NotNull` 어노테이션은 `null`이 아니라고 판단하여 유효성 검사를 통과(200 OK)시켜 버립니다.
- `createMenu`에서 500 에러가 난 이유는 값이 0으로 넘어간 뒤 원시 타입 바인딩 과정에서 예외가 발생해 전역 에러 핸들러가 500으로 처리했기 때문입니다.

#### Solutions
`@NotNull`을 통해 값이 누락된 것을 정확히 검증하기 위해서 원시 타입 `int`를 래퍼 클래스인 `Integer`로 변경했습니다.
- `int`는 기본형(Primitive Type)으로 기본값이 `0`입니다. `null`값을 넣을 수 없기 때문에 반드시 초기화가 필요합니다.
- `Integer`는 기본형인 `int`를 객체로 감싼 래퍼 클래스(Wrapper Class)입니다. 데이터가 없음을 나타내는 `null`을 할당할 수 있어 DB 연동 시 유리합니다.