### PR TITLE
refactor: QueryDSL 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,12 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
-    // ... 기존에 적어주신 testImplementation들 아래에 추가 ...
+    // QueryDSL
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa:7.0'
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // test시 활용할 가짜 DB
     testImplementation 'com.h2database:h2'
 }

--- a/src/main/java/com/team6/backend/global/infrastructure/config/QueryDslConfig.java
+++ b/src/main/java/com/team6/backend/global/infrastructure/config/QueryDslConfig.java
@@ -1,0 +1,14 @@
+package com.team6.backend.global.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/team6/backend/menu/domain/repository/MenuRepository.java
+++ b/src/main/java/com/team6/backend/menu/domain/repository/MenuRepository.java
@@ -1,35 +1,9 @@
 package com.team6.backend.menu.domain.repository;
 
 import com.team6.backend.menu.domain.entity.Menu;
-import io.lettuce.core.dynamic.annotation.Param;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-import java.util.Optional;
 import java.util.UUID;
 
-public interface MenuRepository extends JpaRepository<Menu, UUID> {
-
-    // TODO: QueryDsl 적용해야 함
-    @Query("SELECT m FROM Menu m WHERE " +
-            "(m.store.storeId = CAST(CAST(:storeId AS string) AS uuid)) AND " +
-            "(:keyword IS NULL OR LOWER(m.name) LIKE LOWER(CONCAT('%', CAST(:keyword AS string), '%'))) AND " +
-            "(m.isHidden IS FALSE)"
-    )
-    Page<Menu> searchMenus(
-            @Param("storeId") UUID storeId,
-            @Param("keyword") String keyword,
-            Pageable pageable
-    );
-
-    @Query("SELECT m FROM Menu m JOIN m.store s WHERE s.storeId = :storeId")
-    Page<Menu> findByStore_StoreId(UUID storeId, Pageable pageable);
-
-    @Query("SELECT m FROM Menu m JOIN m.store s WHERE s.storeId = :storeId AND LOWER(m.name) LIKE LOWER(CONCAT('%', :name, '%'))")
-    Page<Menu> findByStore_StoreIdAndNameContainingIgnoreCase(UUID storeId, String name, Pageable pageable);
-
-    @Query("SELECT m FROM Menu m JOIN m.store s WHERE m.menuId = :menuId AND s.storeId = :storeId")
-    Optional<Menu> findByMenuIdAndStore_StoreId(UUID menuId, UUID storeId);
+public interface MenuRepository extends JpaRepository<Menu, UUID>, MenuRepositoryCustom {
 }

--- a/src/main/java/com/team6/backend/menu/domain/repository/MenuRepositoryCustom.java
+++ b/src/main/java/com/team6/backend/menu/domain/repository/MenuRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.team6.backend.menu.domain.repository;
+
+import com.team6.backend.menu.domain.entity.Menu;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MenuRepositoryCustom {
+
+    Page<Menu> searchMenus(UUID storeId, String keyword, Pageable pageable);
+    Page<Menu> findByStore_StoreId(UUID storeId, Pageable pageable);
+    Page<Menu> findByStore_StoreIdAndNameContainingIgnoreCase(UUID storeId, String name, Pageable pageable);
+    Optional<Menu> findByMenuIdAndStore_StoreId(UUID menuId, UUID storeId);
+
+}

--- a/src/main/java/com/team6/backend/menu/domain/repository/MenuRepositoryCustomImpl.java
+++ b/src/main/java/com/team6/backend/menu/domain/repository/MenuRepositoryCustomImpl.java
@@ -1,0 +1,115 @@
+package com.team6.backend.menu.domain.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team6.backend.menu.domain.entity.Menu;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.team6.backend.menu.domain.entity.QMenu.menu;
+import static com.team6.backend.store.domain.entity.QStore.store;
+
+public class MenuRepositoryCustomImpl implements MenuRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MenuRepositoryCustomImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<Menu> searchMenus(UUID storeId, String keyword, Pageable pageable) {
+        return getPagedResult(
+                storeEq(storeId),
+                keywordContains(keyword),
+                menu.isHidden.isFalse(),
+                pageable
+        );
+    }
+
+    @Override
+    public Page<Menu> findByStore_StoreId(UUID storeId, Pageable pageable) {
+        return getPagedResult(
+                storeEq(storeId),
+                null,
+                null,
+                pageable
+        );
+    }
+
+    @Override
+    public Page<Menu> findByStore_StoreIdAndNameContainingIgnoreCase(UUID storeId, String name, Pageable pageable) {
+        return getPagedResult(
+                storeEq(storeId),
+                keywordContains(name),
+                null,
+                pageable
+        );
+    }
+
+    @Override
+    public Optional<Menu> findByMenuIdAndStore_StoreId(UUID menuId, UUID storeId) {
+        Menu fetchOne = queryFactory
+                .selectFrom(menu)
+                .join(menu.store, store)
+                .where(
+                        menu.menuId.eq(menuId),
+                        store.storeId.eq(storeId)
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(fetchOne);
+    }
+
+    private Page<Menu> getPagedResult(BooleanExpression cond1, BooleanExpression cond2, BooleanExpression cond3, Pageable pageable) {
+        List<Menu> content = queryFactory
+                .selectFrom(menu)
+                .innerJoin(menu.store, store).fetchJoin()
+                .where(cond1, cond2, cond3)
+                .orderBy(getOrderSpecifiers(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(menu.count())
+                .from(menu)
+                .innerJoin(menu.store, store)
+                .where(cond1, cond2, cond3);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+        if (pageable.getSort() != null && pageable.getSort().isSorted()) {
+            for (Sort.Order order : pageable.getSort()) {
+                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                PathBuilder<Menu> pathBuilder = new PathBuilder<>(Menu.class, "menu");
+                orders.add(new OrderSpecifier(direction, pathBuilder.get(order.getProperty())));
+            }
+        }
+        return orders.toArray(new OrderSpecifier[0]);
+    }
+
+    private BooleanExpression storeEq(UUID storeId) {
+        return storeId != null ? menu.store.storeId.eq(storeId) : null;
+    }
+
+    private BooleanExpression keywordContains(String keyword) {
+        return StringUtils.hasText(keyword) ? menu.name.containsIgnoreCase(keyword) : null;
+    }
+}

--- a/src/main/java/com/team6/backend/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/team6/backend/store/domain/repository/StoreRepository.java
@@ -1,40 +1,9 @@
 package com.team6.backend.store.domain.repository;
 
 import com.team6.backend.store.domain.entity.Store;
-import io.lettuce.core.dynamic.annotation.Param;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.UUID;
 
-public interface StoreRepository extends JpaRepository<Store, UUID> {
-    // TODO: QueryDsl 적용해야 함
-    @Query("SELECT s FROM Store s WHERE " +
-            "(:keyword IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', CAST(:keyword AS string), '%'))) AND " +
-            "(:categoryId IS NULL OR s.category.categoryId = CAST(CAST(:categoryId AS string) AS uuid)) AND " +
-            "(:areaId IS NULL OR s.area.areaId = CAST(CAST(:areaId AS string) AS uuid)) AND" +
-            "(s.isHidden IS FALSE)"
-    )
-    Page<Store> searchStores(
-            @Param("keyword") String keyword,
-            @Param("categoryId") UUID categoryId,
-            @Param("areaId") UUID areaId,
-            Pageable pageable
-    );
-
-    // TODO: QueryDsl 적용해야 함
-    @Query("SELECT s FROM Store s WHERE " +
-            "(s.owner.id = CAST(CAST(:ownerId AS string) AS uuid)) AND " +
-            "(:keyword IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', CAST(:keyword AS string), '%'))) AND " +
-            "(:categoryId IS NULL OR s.category.categoryId = CAST(CAST(:categoryId AS string) AS uuid)) AND " +
-            "(:areaId IS NULL OR s.area.areaId = CAST(CAST(:areaId AS string) AS uuid))")
-    Page<Store> searchStoresByOwnerId(
-            @Param("ownerId") UUID ownerId,
-            @Param("keyword") String keyword,
-            @Param("categoryId") UUID categoryId,
-            @Param("areaId") UUID areaId,
-            Pageable pageable
-    );
+public interface StoreRepository extends JpaRepository<Store, UUID>, StoreRepositoryCustom {
 }

--- a/src/main/java/com/team6/backend/store/domain/repository/StoreRepositoryCustom.java
+++ b/src/main/java/com/team6/backend/store/domain/repository/StoreRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.team6.backend.store.domain.repository;
+
+import com.team6.backend.store.domain.entity.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface StoreRepositoryCustom {
+
+    Page<Store> searchStores(String keyword, UUID categoryId, UUID areaId, Pageable pageable);
+    Page<Store> searchStoresByOwnerId(UUID ownerId, String keyword, UUID categoryId, UUID areaId, Pageable pageable);
+
+}

--- a/src/main/java/com/team6/backend/store/domain/repository/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/team6/backend/store/domain/repository/StoreRepositoryCustomImpl.java
@@ -1,0 +1,115 @@
+package com.team6.backend.store.domain.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team6.backend.store.domain.entity.Store;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static com.team6.backend.store.domain.entity.QStore.store;
+
+public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public StoreRepositoryCustomImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<Store> searchStores(String keyword, UUID categoryId, UUID areaId, Pageable pageable) {
+        List<Store> content = queryFactory
+                .selectFrom(store)
+                .leftJoin(store.category).fetchJoin()
+                .leftJoin(store.area).fetchJoin()
+                .where(
+                        keywordContains(keyword),
+                        categoryEq(categoryId),
+                        areaEq(areaId),
+                        store.isHidden.isFalse()
+                )
+                .orderBy(getOrderSpecifiers(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(store.count())
+                .from(store)
+                .where(
+                        keywordContains(keyword),
+                        categoryEq(categoryId),
+                        areaEq(areaId),
+                        store.isHidden.isFalse()
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<Store> searchStoresByOwnerId(UUID ownerId, String keyword, UUID categoryId, UUID areaId, Pageable pageable) {
+        List<Store> content = queryFactory
+                .selectFrom(store)
+                .leftJoin(store.category).fetchJoin()
+                .leftJoin(store.area).fetchJoin()
+                .where(
+                        ownerEq(ownerId),
+                        keywordContains(keyword),
+                        categoryEq(categoryId),
+                        areaEq(areaId)
+                )
+                .orderBy(getOrderSpecifiers(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(store.count())
+                .from(store)
+                .where(
+                        ownerEq(ownerId),
+                        keywordContains(keyword),
+                        categoryEq(categoryId),
+                        areaEq(areaId)
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+        if (pageable.getSort() != null && pageable.getSort().isSorted()) {
+            for (Sort.Order order : pageable.getSort()) {
+                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                PathBuilder<Store> pathBuilder = new PathBuilder<>(Store.class, "store");
+                orders.add(new OrderSpecifier(direction, pathBuilder.get(order.getProperty())));
+            }
+        }
+        return orders.toArray(new OrderSpecifier[0]);
+    }
+
+    private BooleanExpression keywordContains(String keyword) {
+        return StringUtils.hasText(keyword) ? store.name.containsIgnoreCase(keyword) : null;
+    }
+    private BooleanExpression categoryEq(UUID categoryId) {
+        return categoryId != null ? store.category.categoryId.eq(categoryId) : null;
+    }
+    private BooleanExpression areaEq(UUID areaId) {
+        return areaId != null ? store.area.areaId.eq(areaId) : null;
+    }
+    private BooleanExpression ownerEq(UUID ownerId) {
+        return ownerId != null ? store.owner.id.eq(ownerId) : null;
+    }
+}

--- a/src/test/java/com/team6/backend/store/domain/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/team6/backend/store/domain/repository/StoreRepositoryTest.java
@@ -349,4 +349,32 @@ class StoreRepositoryTest {
         store.updateRating(5.0);
         assertThat(store.getRating()).isEqualTo(5.0);
     }
+
+    @Test
+    @DisplayName("복합 필터링: 카테고리와 가게 이름 '일부(부분 일치)'가 주어졌을 때 교집합만 정확히 노출되는지 확인")
+    void searchStores_CategoryAndPartialName() {
+        // given
+        // 1. [정답] 카테고리 일치(O), 이름 일부 포함(O)
+        Store targetStore = new Store(owner, category1, area1, "황금올리브 후라이드", "주소1");
+
+        // 2. [오답] 카테고리 불일치(X - 피자 카테고리), 이름 일부 포함(O) -> 카테고리가 달라서 걸러져야 함
+        Store wrongCategoryStore = new Store(owner, category2, area1, "후라이드 피자", "주소2");
+
+        // 3. [오답] 카테고리 일치(O - 치킨 카테고리), 이름 일부 포함(X) -> 이름에 키워드가 없어서 걸러져야 함
+        Store wrongNameStore = new Store(owner, category1, area1, "양념통닭", "주소3");
+
+        storeRepository.save(targetStore);
+        storeRepository.save(wrongCategoryStore);
+        storeRepository.save(wrongNameStore);
+
+        // when
+        // 카테고리는 category1(치킨), 이름 키워드는 "후라이드" (이름의 뒷부분 일부만 입력)
+        PageRequest pageable = PageRequest.of(0, 10);
+        Page<Store> result = storeRepository.searchStores("후라이드", category1.getCategoryId(), null, pageable);
+
+        // then
+        // '후라이드 피자'와 '양념통닭'은 정확히 걸러지고 '황금올리브 후라이드' 1개만 나와야 성공
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getName()).isEqualTo("황금올리브 후라이드");
+    }
 }


### PR DESCRIPTION
- [x] **QueryDSL을 사용하여 지점 검색 시 카테고리, 지점 이름이 복합적으로 필터링되어 노출되게 해주세요.**

  - 구현 방법: `.where()` 절과 `,`를 이용한 AND 결합
    ```java
    .where(
        keywordContains(keyword), // 지점 이름 필터
        categoryEq(categoryId),   // 카테고리 필터
        areaEq(areaId),
        store.isHidden.isFalse()
    )
    ```
  - QueryDSL에서 `.where(조건1, 조건2)` 형태로 넘기면, 내부적으로 이 조건들을 모두 AND 연산자로 묶어서 복합 필터링 쿼리(`WHERE 조건1 AND 조건2`)를 생성합니다.

- [x] **쿼리 파라미터로 카테고리만 입력하면 해당 카테고리의 가게가 노출되도록 구성하세요. (List or Page or Slice 선택)**
  - 구현 방법: `BooleanExpression`을 활용한 동적 쿼리 (`null` 무시)
    ```java
    private BooleanExpression keywordContains(String keyword) {
        return StringUtils.hasText(keyword) ? store.name.containsIgnoreCase(keyword) : null;
    }
    ```
  - QueryDSL은 `.where()` 안에 `null`이 들어오면 그 조건을 아예 없는 취급해 버립니다.

- [x] **쿼리 파라미터로 카테고리와 가게 이름 일부가 입력되면 해당 카테고리에 포함되어있으면서 검색한 가게 이름 일부를 포함하는 가게들이 노출되도록 구성하세요.**
  - 구현 방법: `.containsIgnoreCase()` 메서드 사용 (부분 일치 검색)
      ```java
      store.name.containsIgnoreCase(keyword)
      ```
  - QueryDSL의 `.containsIgnoreCase()`는 SQL문으로 변환될 때 `LIKE '%키워드%'` 형태로 변환됩니다.
  - `IgnoreCase`가 붙었기 때문에 대소문자 구분 없이 가게 이름 중간에 해당 키워드가 포함되어 있기만 하면 무조건 검색 결과에 노출되도록 구성되었습니다.