### PR TITLE
cd.yml 권한 부여

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,6 +30,10 @@ jobs:
           cache: 'gradle'
 
       # 2. 프로젝트 빌드 (테스트 제외하고 jar 파일 생성)
+      # gradlew 파일에 실행 권한 부여
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      
       - name: Build with Gradle
         run: ./gradlew clean build -x test
 


### PR DESCRIPTION
Permission denied (종료 코드 126) 오류는 CI/CD 환경(GitHub Actions 등)에서 매우 자주 발생하는 문제로  gradlew 파일에 실행 권한(Execution Permission)이 없기 때문에 발생했습니다.

보통 윈도우(Windows) 환경에서 파일을 생성해 커밋하거나, 깃(Git) 설정에서 권한 정보가 누락된 채 리눅스 서버로 올라갔을 때 발생하여 따로 권한 부여했습니다.