### PR TITLE
fix: 이미 사용중인 카테고리는 삭제되면 안 됨

### DIFF
--- a/src/main/java/com/team6/backend/category/application/service/CategoryService.java
+++ b/src/main/java/com/team6/backend/category/application/service/CategoryService.java
@@ -8,6 +8,7 @@ import com.team6.backend.global.infrastructure.config.security.util.SecurityUtil
 import com.team6.backend.global.infrastructure.exception.ApplicationException;
 import com.team6.backend.category.domain.exception.CategoryErrorCode;
 import com.team6.backend.global.infrastructure.util.AuthValidator;
+import com.team6.backend.store.domain.repository.StoreRepository;
 import com.team6.backend.user.domain.entity.Role;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +28,7 @@ import java.util.UUID;
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
+    private final StoreRepository storeRepository;
     private final SecurityUtils securityUtils;
     private final AuthValidator authValidator;
 
@@ -100,6 +102,11 @@ public class CategoryService {
                 null,
                 CategoryErrorCode.CATEGORY_FORBIDDEN
         );
+
+        if (storeRepository.existsByCategory_CategoryId(categoryId)) {
+            log.warn("[CATEGORY] 카테고리 삭제 실패: 사용 중인 카테고리입니다. categoryId: {}", categoryId);
+            throw new ApplicationException(CategoryErrorCode.CATEGORY_IN_USE);
+        }
 
         Category category = findCategoryById(categoryId);
         category.markDeleted(securityUtils.getCurrentUserId().toString());

--- a/src/main/java/com/team6/backend/category/domain/exception/CategoryErrorCode.java
+++ b/src/main/java/com/team6/backend/category/domain/exception/CategoryErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CategoryErrorCode implements ErrorCode {
 
+    CATEGORY_IN_USE("CATEGORY_400", HttpStatus.BAD_REQUEST, "이미 사용중인 카테고리입니다."),
     CATEGORY_NOT_FOUND("CATEGORY_404", HttpStatus.NOT_FOUND, "해당 카테고리가 존재하지 않습니다."),
     CATEGORY_FORBIDDEN("CATEGORY_403", HttpStatus.FORBIDDEN, "카테고리에 대한 권한이 없습니다."),
     DUPLICATE_CATEGORY_NAME("CATEGORY_409", HttpStatus.CONFLICT, "이미 존재하는 카테고리 이름입니다.");

--- a/src/main/java/com/team6/backend/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/team6/backend/store/domain/repository/StoreRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface StoreRepository extends JpaRepository<Store, UUID>, StoreRepositoryCustom {
+    boolean existsByCategory_CategoryId(UUID categoryId);
 }

--- a/src/test/java/com/team6/backend/category/application/service/CategoryServiceTest.java
+++ b/src/test/java/com/team6/backend/category/application/service/CategoryServiceTest.java
@@ -8,6 +8,7 @@ import com.team6.backend.global.infrastructure.config.security.util.SecurityUtil
 import com.team6.backend.global.infrastructure.exception.ApplicationException;
 import com.team6.backend.category.domain.exception.CategoryErrorCode;
 import com.team6.backend.global.infrastructure.util.AuthValidator;
+import com.team6.backend.store.domain.repository.StoreRepository;
 import com.team6.backend.user.domain.entity.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.verify;
 class CategoryServiceTest {
 
     @Mock private CategoryRepository categoryRepository;
+    @Mock private StoreRepository storeRepository;
     @Mock private SecurityUtils securityUtils;
     @Mock private AuthValidator authValidator;
 
@@ -146,6 +148,21 @@ class CategoryServiceTest {
         assertThatThrownBy(() -> categoryService.deleteCategory(id))
                 .isInstanceOf(ApplicationException.class)
                 .hasMessage(CategoryErrorCode.CATEGORY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 실패 - 이미 사용 중인 카테고리 (400)")
+    void deleteCategory_Fail_WhenCategoryIsInUse() {
+        // given
+        UUID categoryId = UUID.randomUUID();
+        given(storeRepository.existsByCategory_CategoryId(categoryId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.deleteCategory(categoryId))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessageContaining(CategoryErrorCode.CATEGORY_IN_USE.getMessage());
+
+        verify(storeRepository).existsByCategory_CategoryId(categoryId);
     }
 
 }


### PR DESCRIPTION
**문제:** 삭제된 카테고리를 참조하고 있는 가게를 조회할 때 `EntityNotFoundException` 에러가 발생
**해결:** 사용 중인 카테고리는 삭제하지 못하게 하는 예외(`CATEGORY_IN_USE`) 추가